### PR TITLE
Feature/issue 2 handle api server errors when retrieving episode data

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1,0 +1,9 @@
+# [issue-0-update-gulp]
+
+## Features
+- Updated the version of gulp to 4.0.2 as version 3 was broken when using node version 12.
+- Refactored gulpfile to define methods for tasks and replaced deprecated list parameter with .series.
+## Deployment steps
+- merge issue-0-update-gulp into master
+- npm install.
+- compile assets: `./bin/node_modules/gulp`.

--- a/NOTES.md
+++ b/NOTES.md
@@ -7,3 +7,12 @@
 - merge issue-0-update-gulp into master
 - npm install.
 - compile assets: `./bin/node_modules/gulp`.
+
+# [issue-1-sort-episode-order]
+
+## Features
+- Updated sort method to arrange episodes in season ascending, episode ascending order.
+## How To Test
+- On loading the page "Behind The Laughter - s11e22" is now the last episode. 
+## Deployment steps
+- merge issue-1-sort-episode-order into master 

--- a/NOTES.md
+++ b/NOTES.md
@@ -15,4 +15,17 @@
 ## How To Test
 - On loading the page "Behind The Laughter - s11e22" is now the last episode. 
 ## Deployment steps
-- merge issue-1-sort-episode-order into master 
+- merge issue-1-sort-episode-order into master
+
+# [issue-2-handle-api-server-errors-when-retrieving-episode-data]
+
+## Features
+- Wrapped the guzzle clienyt request in a try/catch to handle exception event and display user friendly message
+## How To Test
+- Attempt refreshing the page several times.
+## Future Improvement
+- Install test suite such as PhpUnit
+- Move the episode loading code into it's own class
+- Throw the exception in a test to verify feature
+## Deployment steps
+- merge issue-2-handle-api-server-errors-when-retrieving-episode-data

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -19,8 +19,8 @@ var resourcePath = './public/resources/'
 
 // Build Sass
 
-gulp.task('sass', ['clean:css'], function () {
-    return gulp.src(sassPath + 'main.scss')
+gulp.task('sass', gulp.series(cleanCss, function () {
+    return gulp.src(sassPath + 'main.scss',{allowEmpty: true})
         .pipe(sourcemaps.init())
         .pipe(sass({
             outputStyle: 'compressed',
@@ -31,12 +31,11 @@ gulp.task('sass', ['clean:css'], function () {
         .pipe(postcss([ autoprefixer({ browsers: ['last 2 versions'] }) ]))
         .pipe(sourcemaps.write())
         .pipe(gulp.dest(buildPath + 'css/'))
-})
-
+}));
 
 // Build JS
 
-gulp.task('js', ['clean:js'], function (){
+gulp.task('js', gulp.series(cleanJs, function (){
     return browserify({
             debug: true, // Generates sourcemaps
             entries: [jsPath + 'main.js']
@@ -45,55 +44,55 @@ gulp.task('js', ['clean:js'], function (){
         .bundle()
         .pipe(source('main.js'))
         .pipe(gulp.dest(buildPath + 'js/'));
-})
+}));
 
 
 // Copy images
 
-gulp.task('copy:images', ['clean:images'], function() {
-    return gulp.src(resourcePath + 'images/**')
+gulp.task('copy:images', gulp.series(cleanImages, function() {
+    return gulp.src(resourcePath + 'images/**',{allowEmpty: true})
         .pipe(gulp.dest(buildPath + 'images/'))
-})
+}));
 
 // Copy fonts
 
-gulp.task('copy:fonts', ['clean:fonts'], function() {
-    return gulp.src(resourcePath + 'fonts/**')
+gulp.task('copy:fonts', gulp.series(cleanFonts, function() {
+    return gulp.src(resourcePath + 'fonts/**',{allowEmpty: true})
         .pipe(gulp.dest(buildPath + 'fonts/'))
-})
+}));
 
 // Clean Fonts
-
-gulp.task('clean:fonts', function(){
+function cleanFonts(){
     return gulp.src(buildPath + 'fonts', {
-        read: false
+        read: false,
+		allowEmpty: true,
     }).pipe(clean())
-})
+};
 
 // Clean Images
 
-gulp.task('clean:images', function(){
+function cleanImages(){
     return gulp.src(buildPath + 'images', {
-        read: false
+        read: false,
+		allowEmpty: true,
     }).pipe(clean())
-})
+};
 
 // Clean CSS
-
-gulp.task('clean:css', function(){
+function cleanCss(){
     return gulp.src(buildPath + 'css', {
-        read: false
+        read: false,
+		allowEmpty: true,
     }).pipe(clean())
-})
+};
 
 // Clean JS
-
-gulp.task('clean:js', function(){
+function cleanJs(){
     return gulp.src(buildPath + 'js', {
-        read: false
+        read: false,
+		allowEmpty: true,
     }).pipe(clean())
-})
-
+};
 
 //Watch
 gulp.task('watch', function () {
@@ -103,4 +102,4 @@ gulp.task('watch', function () {
 
 // Default task
 
-gulp.task('default', ['sass', 'js', 'copy:images', 'copy:fonts'])
+gulp.task('default', gulp.series('sass', 'js', 'copy:images', 'copy:fonts'));

--- a/package.json
+++ b/package.json
@@ -4,15 +4,14 @@
     "autoprefixer": "^6.5.1",
     "browserify": "^13.1.0",
     "browserify-shim": "^3.8.12",
-    "gulp": "^3.9.1",
-    "gulp-browserify": "^0.5.1",
+    "gulp": "^4.0.2",
     "gulp-clean": "^0.3.2",
     "gulp-postcss": "^6.2.0",
     "gulp-rename": "^1.2.2",
     "gulp-sass": "^4.0",
     "gulp-sourcemaps": "^1.8.1",
     "partialify": "^3.1.6",
-    "vinyl-source-stream": "^1.1.0"
+    "vinyl-source-stream": "^2.0"
   },
   "dependencies": {
     "bootstrap-sass": "^3.3.7",

--- a/public/index.php
+++ b/public/index.php
@@ -3,17 +3,23 @@ require_once '../vendor/autoload.php';
 
 //Load Twig templating environment
 $loader = new Twig_Loader_Filesystem('../templates/');
-$twig = new Twig_Environment($loader, ['debug' => true]);
+$twig   = new Twig_Environment($loader, ['debug' => true]);
+$error  = false;
+$data   = [];
 
-//Get the episodes from the API
-$client = new GuzzleHttp\Client();
-$res = $client->request('GET', 'http://3ev.org/dev-test-api/');
-$data = json_decode($res->getBody(), true);
-
-//Sort the episodes
-$seasons  = array_column($data,"season");
-$episodes = array_column($data,"episode");
-array_multisort($seasons, SORT_ASC, $episodes, SORT_ASC, $data);
+try{
+	//Get the episodes from the API
+	$client = new GuzzleHttp\Client();
+	$res    = $client->request('GET', 'http://3ev.org/dev-test-api/');
+	$data   = json_decode($res->getBody(), true);
+	
+	//Sort the episodes
+	$seasons  = array_column($data,"season");
+	$episodes = array_column($data,"episode");
+	array_multisort($seasons, SORT_ASC, $episodes, SORT_ASC, $data);	
+} catch (GuzzleHttp\Exception\ServerException $ex) {
+    $error = true;
+}
 
 //Render the template
-echo $twig->render('page.html', ["episodes" => $data]);
+echo $twig->render('page.html', ["episodes" => $data,"error" => $error]);

--- a/public/index.php
+++ b/public/index.php
@@ -11,7 +11,9 @@ $res = $client->request('GET', 'http://3ev.org/dev-test-api/');
 $data = json_decode($res->getBody(), true);
 
 //Sort the episodes
-array_multisort(array_keys($data), SORT_ASC, SORT_STRING, $data);
+$seasons  = array_column($data,"season");
+$episodes = array_column($data,"episode");
+array_multisort($seasons, SORT_ASC, $episodes, SORT_ASC, $data);
 
 //Render the template
 echo $twig->render('page.html', ["episodes" => $data]);

--- a/templates/page.html
+++ b/templates/page.html
@@ -4,8 +4,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Bobby's Favourite Simpson's Epsiodes</title>
-    <link href="/resources/compiled/css/main.css" rel="stylesheet">
-    <head>
+    <link href="resources/compiled/css/main.css" rel="stylesheet">
+    </head>
 <body>
     <div class="jumbotron header">
       <div class="container-fluid text-center">
@@ -13,6 +13,10 @@
         <p><img class="img-circle" src="resources/img/bobby.jpg"></p>
       </div>
     </div>
+
+   {% if error %}
+    <p class="alert alert-info">Sorry, there was an error. Please try again by reloading the page.</p>
+   {% endif %}
 
     <div class="container">
         {% for episode in episodes %}
@@ -34,6 +38,6 @@
       </div>
     </footer>
 
-  <script type="text/javascript" src="/resources/compiled/js/main.js"></script>
+  <script type="text/javascript" src="resources/compiled/js/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
# [issue-2-handle-api-server-errors-when-retrieving-episode-data]

## Features
- Wrapped the guzzle client request in a try/catch to handle exception event and display user friendly message
## How To Test
- Attempt refreshing the page several times.
## Future Improvement
- Install test suite such as PhpUnit
- Move the episode loading code into it's own class
- Throw the exception in a test to verify feature
## Deployment steps
- merge issue-2-handle-api-server-errors-when-retrieving-episode-data