### PR TITLE
[Issue-001] Fixing episodes ordering issue

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -10,8 +10,10 @@ $client = new GuzzleHttp\Client();
 $res = $client->request('GET', 'http://3ev.org/dev-test-api/');
 $data = json_decode($res->getBody(), true);
 
-//Sort the episodes
-array_multisort(array_keys($data), SORT_ASC, SORT_STRING, $data);
+usort($data, function($a, $b) {
+    $value =  $a['season'] <=> $b['season'];
+    return (0 == $value) ? $a['episode'] <=> $b['episode'] : $value;
+});
 
 //Render the template
 echo $twig->render('page.html', ["episodes" => $data]);


### PR DESCRIPTION
Fixing the ordering of the episodes by using usort to order by season number and then by episode number.

---

**Testing**

Please refresh the page.
---

**Deployment steps**

Tell us what we would need to do to get your changes into production. (We are aware that in this test, this is mostly a case of merging your branch). e.g.

Merge branch `hotfix/issue-1-ordering-issue` into `master`

